### PR TITLE
Order firewall units after network-online to avoid boot lockup

### DIFF
--- a/roles/iptables/templates/mini-pig-firewall.service.j2
+++ b/roles/iptables/templates/mini-pig-firewall.service.j2
@@ -1,16 +1,15 @@
 {{ ansible_managed | comment }}
 [Unit]
-# Type=oneshot, no RemainAfterExit — each start runs ExecStart again,
-# which re-asserts firewall state for the active backend.
-# `systemctl status` normally reports "inactive (dead)"; that is expected.
-# Called by the role at apply time, by mini-pig-firewall.timer
-# periodically, and on boot via WantedBy=multi-user.target.
+# Type=oneshot, no RemainAfterExit: each start re-asserts the ruleset
+# (idempotent; "inactive (dead)" between runs is expected).
+# After=network-online, NOT Before=network-pre: re-applying mid NIC bring-up
+# (`nft -f` atomically delete+recreates the mpig_* tables) triggers a kernel
+# nftables lockup — suspected dynamic rate-limit set teardown vs packet-path
+# race — that hard-hangs boot on cloud-init hosts that block until
+# network-online (e.g. Scaleway Elastic Metal).
 Description=Mini Pig firewall (idempotent apply + drift check)
-DefaultDependencies=no
-Wants=network-pre.target
-Before=network-pre.target shutdown.target
-After=local-fs.target systemd-modules-load.service
-Conflicts=shutdown.target
+Wants=network-online.target
+After=network-online.target
 ConditionPathExists=/usr/local/sbin/mini-pig-firewall-apply
 
 [Service]

--- a/roles/iptables/templates/mpig-randomized-snat.service.j2
+++ b/roles/iptables/templates/mpig-randomized-snat.service.j2
@@ -1,11 +1,12 @@
 {{ ansible_managed | comment }}
 [Unit]
 Description=Mini Pig randomized SNAT (native nft chain at priority srcnat - 10)
-DefaultDependencies=no
-Wants=network-pre.target
-Before=network-pre.target shutdown.target
-After=local-fs.target systemd-modules-load.service nftables.service
-Conflicts=shutdown.target
+# After=network-online, NOT Before=network-pre: same kernel nftables bring-up
+# lockup as mini-pig-firewall.service (re-apply mid NIC bring-up freezes boot
+# on cloud-init hosts). After=nftables.service so the SNAT chain lands after
+# the base ruleset exists.
+Wants=network-online.target
+After=network-online.target nftables.service
 ConditionPathExists=/etc/nftables.d/mpig-randomized-snat.conf
 
 [Service]


### PR DESCRIPTION
## Summary

- Re-order both `mini-pig-firewall.service` and `mpig-randomized-snat.service` to run `After=network-online.target` (with `Wants=`) instead of early, `Before=network-pre.target`. These units re-apply the ruleset via `nft -f`, which atomically deletes and recreates the `mpig_*` tables; doing that mid-NIC-bring-up triggers a kernel nftables lockup that hard-hangs boot on cloud-init hosts that block until `network-online` (e.g. Scaleway Elastic Metal).
- Drop `DefaultDependencies=no`, the `network-pre.target` `Wants=`/`Before=`, and `Conflicts=shutdown.target` from both units — they no longer belong to the early pre-network boot phase, so the standard default service dependencies now apply.
- Keep `mpig-randomized-snat.service` ordered `After=nftables.service` so its SNAT chain still lands after the base ruleset exists. The decoupling from `nftables.service` is preserved — this is ordering only, still no `PartOf=`/`ReloadPropagatedFrom=`.
- No change to rule content, the timers, or steady-state drift re-application — only boot-time ordering moves later.