### PR TITLE
Purge stale kernels in init role to stop /boot filling up

### DIFF
--- a/roles/init/AGENTS.md
+++ b/roles/init/AGENTS.md
@@ -59,19 +59,20 @@ Conventions to keep when editing:
 | 0 | bare `user:` task | resolves `ansible_user`'s home into `_init_user_info` (consumed by `s3.yml`). |
 | 1 | `grub.yml` | also tagged `init-apt` (it touches dpkg/debconf state). |
 | 2 | `apt.yml` | |
-| 3 | `dns.yml` | ends with `meta: flush_handlers`. |
-| 4 | `users.yml` | |
-| 5 | `time.yml` | ends with `meta: flush_handlers`. |
-| 6 | `kernel.yml` | |
-| 7 | `sysctl.yml` | |
-| 8 | `hosts.yml` | |
-| 9 | `ssh.yml` | |
-| 10 | `mount.yml` | only when `init_block_dev != ''`. |
-| 11 | `s3.yml` | only when both AWS keys are set. |
-| 12 | `logs.yml` | |
-| 13 | reboot decision task | notifies `reboot host` (see Handlers & reboot). |
+| 3 | `apt-cleanup.yml` | only when `init_apt_kernel_cleanup`; tagged `init-apt` + `init-apt-cleanup`. |
+| 4 | `dns.yml` | ends with `meta: flush_handlers`. |
+| 5 | `users.yml` | |
+| 6 | `time.yml` | ends with `meta: flush_handlers`. |
+| 7 | `kernel.yml` | |
+| 8 | `sysctl.yml` | |
+| 9 | `hosts.yml` | |
+| 10 | `ssh.yml` | |
+| 11 | `mount.yml` | only when `init_block_dev != ''`. |
+| 12 | `s3.yml` | only when both AWS keys are set. |
+| 13 | `logs.yml` | |
+| 14 | reboot decision task | notifies `reboot host` (see Handlers & reboot). |
 
-The two `meta: flush_handlers` (dns step 3, time step 5) start
+The two `meta: flush_handlers` (dns step 4, time step 6) start
 systemd-resolved / systemd-timesyncd within the run. They also constrain when
 the reboot may be notified — see below.
 
@@ -93,6 +94,18 @@ the reboot may be notified — see below.
   When `init_apt_reboot_if_required`, computes `_init_apt_will_reboot`
   (true if `/var/run/reboot-required` exists OR running kernel != newest
   installed). The actual reboot is deferred to a handler (see below).
+  Old-kernel purging lives in its own area (`apt-cleanup.yml`, below).
+- **apt-cleanup.yml** — runs right after `apt.yml`, gated on
+  `init_apt_kernel_cleanup` (default true). From `package_facts` it groups
+  every versioned `linux-{image,headers,modules,kbuild,compiler}-*` package by
+  minor (X.Y) line, keeps the `init_apt_kernel_versions_keep` (default 2)
+  newest patch versions per line plus the running kernel, and purges the rest.
+  Match is by the version embedded in the package name, so
+  stock/backports/metapackage kernels are all covered; version-less
+  metapackages like `linux-image-amd64` never match and are never touched.
+  Before purging, an `assert` guard fails the run if the computed remove set
+  ever targets the running kernel (`ansible_facts['kernel']`) — defence in
+  depth, since the running kernel is already force-kept.
 - **dns.yml** — installs a dhclient hook to stop DHCP from rewriting DNS;
   ensures `systemd-resolved`; renders the DNS-over-TLS drop-in from
   `init_resolved_dns` (notify `restart systemd-resolved`); points
@@ -149,9 +162,9 @@ Two facts about handlers drive the reboot design:
    (and everything else). Keep it last; if you add a handler, put it before
    `reboot host`.
 2. **A notified handler fires at the next `meta: flush_handlers` or at
-   end-of-play.** Because `dns.yml` (step 3) and `time.yml` (step 5) flush,
-   the reboot must only be *notified after step 5*, or it would fire mid-play
-   before `kernel.yml` (step 6) rewrote the cmdline / `grub.cfg`.
+   end-of-play.** Because `dns.yml` (step 4) and `time.yml` (step 6) flush,
+   the reboot must only be *notified after step 6*, or it would fire mid-play
+   before `kernel.yml` (step 7) rewrote the cmdline / `grub.cfg`.
 
 So the reboot is notified from a **single** decision task at the end of
 `tasks/main.yml` that aggregates both triggers — APT
@@ -182,6 +195,9 @@ Defaults that change behaviour materially (`defaults/main.yml`):
 - `init_apt_upgrade` (false) — run `apt upgrade --full`.
 - `init_apt_reboot_if_required` (false) — enables reboot-required detection
   (and thus the reboot path).
+- `init_apt_kernel_cleanup` (true) — purge stale kernels at the end of
+  `apt.yml`; `init_apt_kernel_versions_keep` (2) — how many newest patch
+  versions to keep per minor (X.Y) line (running kernel always kept).
 - `init_cmdline_linux` ("") — kernel cmdline; empty means leave it untouched.
 - `init_block_dev` ("") / `init_mount_point` (`/data`) / `init_block_dev_ssd`
   — data-disk mount; empty `init_block_dev` skips `mount.yml`.

--- a/roles/init/defaults/main.yml
+++ b/roles/init/defaults/main.yml
@@ -42,6 +42,12 @@ init_aws_secret_access_key: ""
 init_apt_upgrade: false
 init_apt_reboot_if_required: false
 
+# Purge old kernels so /boot does not fill up. Explicitly-installed kernels
+# (e.g. Debian backports) carry no metapackage dep, so apt autoremove never
+# reaps them. Keep the N newest patch versions of each minor (X.Y) line.
+init_apt_kernel_cleanup: true
+init_apt_kernel_versions_keep: 2
+
 # Manual override of grub-pc/install_devices. Empty = autodetect from lsblk
 # (BIOS hosts only; UEFI and hosts without grub-pc are skipped).
 init_grub_install_devices: []

--- a/roles/init/tasks/apt-cleanup.yml
+++ b/roles/init/tasks/apt-cleanup.yml
@@ -1,0 +1,84 @@
+---
+# Copyright © 2026 kogeler
+# SPDX-License-Identifier: Apache-2.0
+
+# Old-kernel cleanup: keep only the N newest patch versions of each minor
+# (X.Y) line plus the running kernel; purge every other versioned kernel
+# package (image/headers/kbuild/modules). Matches by the version embedded in
+# the package name, so it covers stock, backports and metapackage-tracked
+# kernels alike. Version-less metapackages (linux-image-amd64) never match.
+# Gated as a whole from main.yml on init_apt_kernel_cleanup.
+- name: init | apt-cleanup | gather package facts
+  ansible.builtin.package_facts:
+    manager: apt
+
+- name: init | apt-cleanup | list installed kernel-versioned packages
+  ansible.builtin.set_fact:
+    _init_kernel_pkgs: >-
+      {{ ansible_facts.packages.keys()
+         | select('match', '^linux-(image|headers|modules|kbuild|compiler)-.*[0-9]+\.[0-9]+\.[0-9]+')
+         | list }}
+
+- name: init | apt-cleanup | derive running and installed kernel versions
+  ansible.builtin.set_fact:
+    _init_kernel_running_ver: >-
+      {{ ansible_facts['kernel']
+         | regex_replace('^([0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?).*$', '\1') }}
+    _init_kernel_minors: >-
+      {{ _init_kernel_pkgs
+         | map('regex_replace', '^.*?([0-9]+\.[0-9]+)\.[0-9]+.*$', '\1')
+         | unique | list }}
+    _init_kernel_vers: >-
+      {{ _init_kernel_pkgs
+         | map('regex_replace', '^.*?([0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?).*$', '\1')
+         | unique | list }}
+
+- name: init | apt-cleanup | select kernel versions to keep (N newest per minor)
+  ansible.builtin.set_fact:
+    _init_kernel_keep_vers: >-
+      {{ (_init_kernel_keep_vers | default([])) +
+         (_init_kernel_vers
+          | select('match', '^' ~ (item | regex_escape) ~ '\.')
+          | community.general.version_sort | reverse | list)[:init_apt_kernel_versions_keep | int] }}
+  loop: "{{ _init_kernel_minors }}"
+
+- name: init | apt-cleanup | compute old kernel versions to purge
+  ansible.builtin.set_fact:
+    _init_kernel_remove_vers: >-
+      {{ _init_kernel_vers
+         | difference((_init_kernel_keep_vers | default([])) + [_init_kernel_running_ver])
+         | list }}
+
+- name: init | apt-cleanup | resolve old kernel package names
+  ansible.builtin.set_fact:
+    _init_kernel_remove_pkgs: >-
+      {{ _init_kernel_pkgs
+         | select('match', '^.*?(' ~ (_init_kernel_remove_vers | map('regex_escape') | join('|')) ~ ')([^0-9]|$)')
+         | list }}
+  when: _init_kernel_remove_vers | length > 0
+
+# Safety net: the running kernel is already force-kept above, so it must never
+# reach the purge set. Fail loudly before any apt action if it somehow did.
+- name: init | apt-cleanup | guard - never purge the running kernel
+  ansible.builtin.assert:
+    that:
+      - _init_kernel_running_ver not in _init_kernel_remove_vers
+      - >-
+        _init_kernel_remove_pkgs | default([])
+        | select('search', (ansible_facts['kernel'] | regex_escape)) | list | length == 0
+    fail_msg: >-
+      Refusing to remove old kernels: the computed purge set targets the
+      running kernel ({{ ansible_facts['kernel'] }}). Aborting before any
+      package is removed.
+    quiet: true
+  when: _init_kernel_remove_vers | length > 0
+
+- name: init | apt-cleanup | purge old kernel packages
+  ansible.builtin.apt:
+    name: "{{ _init_kernel_remove_pkgs }}"
+    state: absent
+    purge: true
+    autoremove: true
+    update_cache: false
+    force_apt_get: true
+  when: _init_kernel_remove_pkgs | default([]) | length > 0

--- a/roles/init/tasks/main.yml
+++ b/roles/init/tasks/main.yml
@@ -25,6 +25,14 @@
   when: init_flow_control_apt | bool
   tags: ['init', 'init-apt']
 
+- name: init | apt-cleanup
+  ansible.builtin.include_tasks:
+    file: apt-cleanup.yml
+    apply:
+      tags: ['init', 'init-apt', 'init-apt-cleanup']
+  when: (init_flow_control_apt | bool) and (init_apt_kernel_cleanup | bool)
+  tags: ['init', 'init-apt', 'init-apt-cleanup']
+
 - name: init | dns
   ansible.builtin.include_tasks:
     file: dns.yml


### PR DESCRIPTION
## Summary

- Add a new `apt-cleanup` area to the `init` role that purges accumulated old
  kernels. Explicitly-installed kernels (e.g. Debian backports) carry no
  metapackage dependency, so `apt autoremove` never reaps them and old
  versions pile up until `/boot` fills. The cleanup keeps the N newest patch
  versions of each minor (X.Y) line plus the running kernel, and purges the
  rest.
- Match every versioned `linux-{image,headers,modules,kbuild,compiler}-*`
  package by the version embedded in its name, so stock, backports and
  metapackage-tracked kernels are all covered uniformly; version-less
  metapackages such as `linux-image-amd64` never match and are left untouched.
- Force-keep the running kernel even when it is not among the N newest (e.g. a
  reboot-pending host running an older kernel), preventing the active kernel
  from ever being removed.
- Add an `assert` guard that aborts the run *before* any `apt` action if the
  computed removal set ever targets the running kernel — defence-in-depth
  against a future regression in the version-selection logic.
- Expose two new variables: `init_apt_kernel_cleanup` (default `true`) to gate
  the feature and `init_apt_kernel_versions_keep` (default `2`) for N; wire the
  area into the dispatcher right after `apt`, gated on both the existing
  `init_flow_control_apt` flag and the new toggle, with `init-apt` /
  `init-apt-cleanup` tags.
