### PR TITLE
Fix Telegraf deprecation/log-spam and init kernel reboot crash

### DIFF
--- a/roles/init/tasks/apt.yml
+++ b/roles/init/tasks/apt.yml
@@ -138,12 +138,28 @@
   register: _init_apt_kernel_modules_register
   when: init_apt_reboot_if_required | bool
 
+# version_sort (LooseVersion) crashes with "'<' not supported between instances
+# of 'int' and 'str'" on raw /lib/modules names whose components misalign by type
+# (stock amd64 vs meta/xanmod). Normalise to a bare X.Y.Z(-N) version first (as
+# apt-cleanup.yml does) so version_sort only ever sees type-consistent values.
+- name: init | apt | derive running and newest installed kernel versions
+  ansible.builtin.set_fact:
+    _init_apt_running_kernel_ver: >-
+      {{ ansible_facts['kernel']
+         | regex_replace('^([0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?).*$', '\1') }}
+    _init_apt_latest_kernel_ver: >-
+      {{ _init_apt_kernel_modules_register.files | map(attribute='path') | map('basename')
+         | select('match', '^[0-9]+\.[0-9]+\.[0-9]+')
+         | map('regex_replace', '^([0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?).*$', '\1')
+         | community.general.version_sort | last }}
+  when: init_apt_reboot_if_required | bool
+
 - name: init | apt | determine if reboot is required
   ansible.builtin.set_fact:
     _init_apt_will_reboot: >-
       {{
         _init_apt_reboot_required_file_register.stat.exists or
-        (ansible_facts['kernel'] != (_init_apt_kernel_modules_register.files | map(attribute='path') | map('basename') | community.general.version_sort | last))
+        (_init_apt_running_kernel_ver != _init_apt_latest_kernel_ver)
       }}
   when: init_apt_reboot_if_required | bool
 
@@ -151,8 +167,8 @@
   ansible.builtin.debug:
     msg:
       - "reboot-required file exists: {{ _init_apt_reboot_required_file_register.stat.exists }}"
-      - "running kernel: {{ ansible_facts['kernel'] }}"
-      - "latest installed kernel: {{ _init_apt_kernel_modules_register.files | map(attribute='path') | map('basename') | community.general.version_sort | last }}"
+      - "running kernel: {{ ansible_facts['kernel'] }} ({{ _init_apt_running_kernel_ver }})"
+      - "latest installed kernel: {{ _init_apt_latest_kernel_ver }}"
       - "packages upgraded: {{ _init_apt_upgrade_register.changed | default(false) }}"
       - "packages installed: {{ _init_apt_install_packages_register.changed | default(false) }}"
       - "will reboot: {{ _init_apt_will_reboot | bool }}"

--- a/roles/telegraf/tasks/main.yml
+++ b/roles/telegraf/tasks/main.yml
@@ -135,19 +135,14 @@
       notify: restart telegraf on host
       when: telegraf_rpi_gpu_temp_enable | bool
 
-    - name: telegraf | add telegraf user to sudoers.d
-      ansible.builtin.lineinfile:
-        path: /etc/sudoers.d/telegraf
-        line: "{{ item }}"
-        state: "{% if telegraf_disk_smart_enable | bool %}present{% else %}absent{% endif %}"
-        mode: 0600
-        create: yes
+    - name: telegraf | manage /etc/sudoers.d/telegraf
+      ansible.builtin.template:
+        src: sudoers.j2
+        dest: /etc/sudoers.d/telegraf
+        owner: root
+        group: root
+        mode: "0600"
         validate: "visudo -cf %s"
-      loop:
-        - "telegraf ALL = NOPASSWD: /usr/sbin/smartctl"
-        - "Defaults!/usr/sbin/smartctl !logfile, !syslog, !pam_session"
-        - "telegraf ALL = NOPASSWD: /usr/sbin/nvme"
-        - "Defaults!/usr/sbin/nvme !logfile, !syslog, !pam_session"
       notify: restart telegraf on host
 
     - name: telegraf | configure UPS monitoring (NUT)

--- a/roles/telegraf/templates/sudoers.j2
+++ b/roles/telegraf/templates/sudoers.j2
@@ -1,0 +1,20 @@
+# Managed by Ansible
+# Defaults!<cmd> !logfile,!syslog,!pam_session keep telegraf's per-interval sudo calls out of the logs.
+{% if telegraf_disk_smart_enable | bool %}
+# inputs.smart (use_sudo)
+telegraf ALL = NOPASSWD: /usr/sbin/smartctl
+Defaults!/usr/sbin/smartctl !logfile, !syslog, !pam_session
+telegraf ALL = NOPASSWD: /usr/sbin/nvme
+Defaults!/usr/sbin/nvme !logfile, !syslog, !pam_session
+{% endif %}
+{% if telegraf_lvm_enable | bool %}
+# inputs.lvm (use_sudo) + lvm.py via inputs.exec
+telegraf ALL = NOPASSWD: /usr/sbin/pvs
+Defaults!/usr/sbin/pvs !logfile, !syslog, !pam_session
+telegraf ALL = NOPASSWD: /usr/sbin/vgs
+Defaults!/usr/sbin/vgs !logfile, !syslog, !pam_session
+telegraf ALL = NOPASSWD: /usr/sbin/lvs
+Defaults!/usr/sbin/lvs !logfile, !syslog, !pam_session
+telegraf ALL = NOPASSWD: {{ telegraf_base_dir }}/lvm.py
+Defaults!{{ telegraf_base_dir }}/lvm.py !logfile, !syslog, !pam_session
+{% endif %}

--- a/roles/telegraf/templates/telegraf.conf.j2
+++ b/roles/telegraf/templates/telegraf.conf.j2
@@ -29,6 +29,9 @@
   ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
   round_interval = true
 
+  ## Explicit since the default flips to true in Telegraf 1.40 (no aggregators here).
+  skip_processors_after_aggregators = true
+
   ## Telegraf will send metrics to outputs in batches of at most
   ## metric_batch_size metrics.
   ## This controls the size of writes that Telegraf sends to output plugins.
@@ -749,7 +752,7 @@
 #   #lvs_binary = "/usr/sbin/lvs"
 
 [[inputs.exec]]
-  commands = ["sudo {{ telegraf_base_dir }}/lvm.py"]
+  commands = [["sudo", "{{ telegraf_base_dir }}/lvm.py"]]
   timeout  = "5s"
   data_format = "influx"
   interval = "60s"
@@ -1134,7 +1137,7 @@
 
 {% if telegraf_rpi_gpu_temp_enable %}
 [[inputs.exec]]
-  commands = [ "/usr/bin/vcgencmd measure_temp" ]
+  commands = [["/usr/bin/vcgencmd", "measure_temp"]]
   name_override = "rpi_gpu_temperature"
   data_format = "grok"
   grok_patterns = ["%{NUMBER:value:float}"]
@@ -1143,6 +1146,6 @@
 
 [[inputs.exec]]
   commands = [
-    "/bin/sh -c 'echo \"linux_kernel_info,version=$(cat /proc/sys/kernel/osrelease | tr -d \"\\n\")\" value=1'"
+    ["/bin/sh", "-c", "echo \"linux_kernel_info,version=$(cat /proc/sys/kernel/osrelease | tr -d \"\\n\")\" value=1"]
   ]
   data_format = "influx"


### PR DESCRIPTION
## Summary

- Telegraf: explicitly set `skip_processors_after_aggregators` in the `[agent]` block and convert all `inputs.exec` `commands` from the deprecated shell-string form to argv arrays. This clears the Telegraf 1.40 default-change warning and the 1.39 `inputs.exec` `DeprecationWarning` (removal slated for 1.45). Behavior is unchanged — there are no aggregators/processors, and the `sh -c` script still does the shell work.
- Telegraf: consolidate `/etc/sudoers.d/telegraf` into a single template (replacing two parallel `lineinfile` tasks) and add `NOPASSWD` + `!logfile, !syslog, !pam_session` defaults for the LVM commands (`pvs`/`vgs`/`lvs` from `inputs.lvm`, and `lvm.py` from `inputs.exec`). This stops the per-interval `sudo`/`pam_unix(session)` spam in the system log and makes the role grant the LVM sudo it actually needs (previously only smartctl/nvme were managed).
- init: the "determine if reboot is required" task crashed with `community.general.version_sort` raising `'<' not supported between instances of 'int' and 'str'` on hosts whose `/lib/modules` mixes kernel name formats (stock vs meta/backports/xanmod). Normalize each name to a bare `X.Y.Z(-N)` version (and drop non-version directories) before sorting, so `version_sort` only ever compares type-consistent values. This mirrors the existing approach in `apt-cleanup.yml` and is fully native (no shell).
