### PR TITLE
Add optional podman network attachment for naive_proxy/telemt pods

### DIFF
--- a/roles/naive_proxy/defaults/main.yml
+++ b/roles/naive_proxy/defaults/main.yml
@@ -188,6 +188,12 @@ naive_proxy_config_dir: /opt/naive-proxy
 
 # -- Network ------------------------------------------------------------------
 
+# Optional: attach the pod to a pre-existing podman network instead of the
+# default one. Empty string keeps podman's default network. The role never
+# creates or manages networks — create it out-of-band and set this to its
+# name to attach (e.g. a dual-stack network providing IPv6 egress via NAT).
+naive_proxy_pod_network: ""
+
 naive_proxy_listen_port: 443
 # External port visible to clients (e.g. after port forwarding).
 # Used in client configs. Defaults to listen_port.

--- a/roles/naive_proxy/templates/pod.service.j2
+++ b/roles/naive_proxy/templates/pod.service.j2
@@ -9,6 +9,9 @@ RemainAfterExit=yes
 ExecStartPre=-/usr/bin/podman pod rm --ignore {{ _naive_proxy_pod_name }}
 ExecStart=/usr/bin/podman pod create \
         --name {{ _naive_proxy_pod_name }} \
+{% if naive_proxy_pod_network | length > 0 %}
+        --network {{ naive_proxy_pod_network }} \
+{% endif %}
 {% if naive_proxy_molecule_mode %}
         --publish {{ _naive_proxy_pebble_port }}:{{ _naive_proxy_pebble_port }} \
         --publish {{ _naive_proxy_pebble_mgmt_port }}:{{ _naive_proxy_pebble_mgmt_port }} \

--- a/roles/telemt/defaults/main.yml
+++ b/roles/telemt/defaults/main.yml
@@ -17,6 +17,12 @@ telemt_container_config_path: /run/telemt/config.toml
 
 # -- Network ------------------------------------------------------------------
 
+# Optional: attach the pod to a pre-existing podman network instead of the
+# default one. Empty string keeps podman's default network. The role never
+# creates or manages networks — create it out-of-band and set this to its
+# name to attach (e.g. a dual-stack network providing IPv6 egress via NAT).
+telemt_pod_network: ""
+
 telemt_listen_port: 443
 
 # -- Container options ---------------------------------------------------------

--- a/roles/telemt/templates/pod.service.j2
+++ b/roles/telemt/templates/pod.service.j2
@@ -9,6 +9,9 @@ RemainAfterExit=yes
 ExecStartPre=-/usr/bin/podman pod rm --ignore {{ _telemt_pod_name }}
 ExecStart=/usr/bin/podman pod create \
         --name {{ _telemt_pod_name }} \
+{% if telemt_pod_network | length > 0 %}
+        --network {{ telemt_pod_network }} \
+{% endif %}
 {% if telemt_publish_api and telemt_api_enabled %}
         --publish {{ telemt_api_bind }}:{{ telemt_api_port }}:{{ telemt_api_port }} \
 {% endif %}


### PR DESCRIPTION
## Summary

- Add `naive_proxy_pod_network` and `telemt_pod_network` (both default `""`). When set, the pod's `podman pod create` gains `--network <name>`, attaching the pod to a pre-existing podman network instead of podman's default — e.g. a dual-stack network that provides IPv6 egress via NAT.
- Opt-in and non-breaking: with the empty default the `--network` flag is not emitted, so existing deployments keep podman's default-network behavior unchanged.
- The role deliberately does not create or manage networks — the network must be created out-of-band and referenced by name; the role only attaches the pod to it.
